### PR TITLE
Add EditorClient to the list of supported editors

### DIFF
--- a/QuickCursor-Info.plist
+++ b/QuickCursor-Info.plist
@@ -35,6 +35,7 @@
 	<key>QCEditInChoices</key>
 	<array>
 		<string>org.gnu.Aquamacs</string>
+                <string>org.pyrite.EditorClient</string>
 		<string>com.barebones.bbedit</string>
 		<string>com.metaclassy.byword</string>
 		<string>com.aynimac.CotEditor</string>


### PR DESCRIPTION
This ODB editor client allows users of Emacs versions other than
Aquamacs to use QuickCursor too by hooking ODB into the standard
emacsclient command-line mechanism.

Thanks for QuickCursor!
