### PR TITLE
Added "Insert Only" mode to QuickCursor

### DIFF
--- a/English.lproj/MainMenu.xib
+++ b/English.lproj/MainMenu.xib
@@ -61,7 +61,7 @@
 			<object class="NSWindowTemplate" id="448742277">
 				<int key="NSWindowStyleMask">7</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{235, 207}, {435, 331}}</string>
+				<string key="NSWindowRect">{{235, 207}, {435, 385}}</string>
 				<int key="NSWTFlags">1685588992</int>
 				<string key="NSWindowTitle">QuickCursor Preferences</string>
 				<string key="NSWindowClass">NSWindow</string>
@@ -75,9 +75,10 @@
 						<object class="NSPopUpButton" id="1039590887">
 							<reference key="NSNextResponder" ref="248881203"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{102, 286}, {153, 26}}</string>
+							<string key="NSFrame">{{102, 314}, {153, 26}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="868578286"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSPopUpButtonCell" key="NSCell" id="250213868">
@@ -115,15 +116,16 @@
 						<object class="NSTextField" id="521699642">
 							<reference key="NSNextResponder" ref="248881203"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 293}, {82, 17}}</string>
+							<string key="NSFrame">{{17, 322}, {82, 17}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="1039590887"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="146579460">
 								<int key="NSCellFlags">68288064</int>
 								<int key="NSCellFlags2">71304192</int>
-								<string key="NSContents">Shortcuts:</string>
+								<string key="NSContents">Edit All</string>
 								<reference key="NSSupport" ref="752916645"/>
 								<reference key="NSControlView" ref="521699642"/>
 								<object class="NSColor" key="NSBackgroundColor" id="641415861">
@@ -162,6 +164,7 @@
 											<string key="NSFrameSize">{394, 171}</string>
 											<reference key="NSSuperview" ref="530525660"/>
 											<reference key="NSWindow"/>
+											<reference key="NSNextKeyView" ref="1497048"/>
 											<int key="NSViewLayerContentsRedrawPolicy">2</int>
 											<bool key="NSEnabled">YES</bool>
 											<object class="NSTableHeaderView" key="NSHeaderView" id="408726943">
@@ -170,15 +173,14 @@
 												<string key="NSFrameSize">{394, 17}</string>
 												<reference key="NSSuperview" ref="205750030"/>
 												<reference key="NSWindow"/>
+												<reference key="NSNextKeyView" ref="530525660"/>
 												<int key="NSViewLayerContentsRedrawPolicy">2</int>
 												<reference key="NSTableView" ref="59988265"/>
 											</object>
-											<object class="_NSCornerView" key="NSCornerView" id="510438226">
-												<reference key="NSNextResponder" ref="278119067"/>
+											<object class="_NSCornerView" key="NSCornerView">
+												<nil key="NSNextResponder"/>
 												<int key="NSvFlags">-2147483392</int>
 												<string key="NSFrame">{{224, 0}, {16, 17}}</string>
-												<reference key="NSSuperview" ref="278119067"/>
-												<reference key="NSWindow"/>
 												<int key="NSViewLayerContentsRedrawPolicy">2</int>
 											</object>
 											<object class="NSMutableArray" key="NSTableColumns">
@@ -293,6 +295,7 @@
 									<string key="NSFrame">{{224, 17}, {15, 102}}</string>
 									<reference key="NSSuperview" ref="278119067"/>
 									<reference key="NSWindow"/>
+									<reference key="NSNextKeyView" ref="941871519"/>
 									<int key="NSViewLayerContentsRedrawPolicy">2</int>
 									<reference key="NSTarget" ref="278119067"/>
 									<string key="NSAction">_doScroller:</string>
@@ -304,6 +307,7 @@
 									<string key="NSFrame">{{1, 301}, {381, 15}}</string>
 									<reference key="NSSuperview" ref="278119067"/>
 									<reference key="NSWindow"/>
+									<reference key="NSNextKeyView" ref="7174257"/>
 									<int key="NSViewLayerContentsRedrawPolicy">2</int>
 									<int key="NSsFlags">1</int>
 									<reference key="NSTarget" ref="278119067"/>
@@ -326,19 +330,17 @@
 									<reference key="NSBGColor" ref="1012495200"/>
 									<int key="NScvFlags">4</int>
 								</object>
-								<reference ref="510438226"/>
 							</object>
-							<string key="NSFrame">{{20, 49}, {396, 189}}</string>
+							<string key="NSFrame">{{19, 49}, {396, 189}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="530525660"/>
+							<reference key="NSNextKeyView" ref="205750030"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<int key="NSsFlags">133682</int>
 							<reference key="NSVScroller" ref="1497048"/>
 							<reference key="NSHScroller" ref="941871519"/>
 							<reference key="NSContentView" ref="530525660"/>
 							<reference key="NSHeaderClipView" ref="205750030"/>
-							<reference key="NSCornerView" ref="510438226"/>
 							<bytes key="NSScrollAmts">QSAAAEEgAABBmAAAQZgAAA</bytes>
 						</object>
 						<object class="NSTextField" id="942101536">
@@ -347,12 +349,13 @@
 							<string key="NSFrame">{{17, 246}, {401, 17}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="278119067"/>
 							<int key="NSViewLayerContentsRedrawPolicy">2</int>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="385269293">
 								<int key="NSCellFlags">68288064</int>
 								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Temporary File Extensions:</string>
+								<string key="NSContents">Temporary File Extensions</string>
 								<reference key="NSSupport" ref="752916645"/>
 								<reference key="NSControlView" ref="942101536"/>
 								<reference key="NSBackgroundColor" ref="641415861"/>
@@ -362,9 +365,10 @@
 						<object class="NSBox" id="138723173">
 							<reference key="NSNextResponder" ref="248881203"/>
 							<int key="NSvFlags">12</int>
-							<string key="NSFrame">{{20, 269}, {395, 5}}</string>
+							<string key="NSFrame">{{19, 269}, {395, 5}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="942101536"/>
 							<string key="NSOffsets">{0, 0}</string>
 							<object class="NSTextFieldCell" key="NSTitleCell">
 								<int key="NSCellFlags">67239424</int>
@@ -393,9 +397,10 @@
 						<object class="NSButton" id="7174257">
 							<reference key="NSNextResponder" ref="248881203"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{20, 19}, {40, 23}}</string>
+							<string key="NSFrame">{{19, 19}, {40, 23}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="659126509"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="353456057">
 								<int key="NSCellFlags">-2080244224</int>
@@ -418,9 +423,10 @@
 						<object class="NSButton" id="659126509">
 							<reference key="NSNextResponder" ref="248881203"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{59, 19}, {40, 23}}</string>
+							<string key="NSFrame">{{58, 19}, {40, 23}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="406485899">
 								<int key="NSCellFlags">-2080244224</int>
@@ -443,18 +449,105 @@
 						<object class="NSCustomView" id="868578286">
 							<reference key="NSNextResponder" ref="248881203"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{260, 289}, {155, 22}}</string>
+							<string key="NSFrame">{{260, 318}, {155, 22}}</string>
 							<reference key="NSSuperview" ref="248881203"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="538635083"/>
 							<string key="NSClassName">SRRecorderControl</string>
 						</object>
+						<object class="NSPopUpButton" id="945329815">
+							<reference key="NSNextResponder" ref="248881203"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{102, 286}, {153, 26}}</string>
+							<reference key="NSSuperview" ref="248881203"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="155242521"/>
+							<int key="NSViewLayerContentsRedrawPolicy">2</int>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSPopUpButtonCell" key="NSCell" id="664626514">
+								<int key="NSCellFlags">-2076049856</int>
+								<int key="NSCellFlags2">134219776</int>
+								<reference key="NSSupport" ref="752916645"/>
+								<reference key="NSControlView" ref="945329815"/>
+								<int key="NSButtonFlags">-2035138305</int>
+								<int key="NSButtonFlags2">129</int>
+								<reference key="NSAlternateImage" ref="752916645"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">400</int>
+								<int key="NSPeriodicInterval">75</int>
+								<nil key="NSMenuItem"/>
+								<bool key="NSMenuItemRespectAlignment">YES</bool>
+								<object class="NSMenu" key="NSMenu" id="769083916">
+									<string key="NSTitle">OtherViews</string>
+									<object class="NSMutableArray" key="NSMenuItems">
+										<bool key="EncodedWithXMLCoder">YES</bool>
+									</object>
+									<reference key="NSMenuFont" ref="752916645"/>
+								</object>
+								<int key="NSSelectedIndex">-1</int>
+								<int key="NSPreferredEdge">1</int>
+								<bool key="NSUsesItemFromMenu">YES</bool>
+								<bool key="NSAltersState">YES</bool>
+								<int key="NSArrowPosition">2</int>
+							</object>
+						</object>
+						<object class="NSCustomView" id="155242521">
+							<reference key="NSNextResponder" ref="248881203"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{261, 288}, {155, 22}}</string>
+							<reference key="NSSuperview" ref="248881203"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="138723173"/>
+							<string key="NSClassName">SRRecorderControl</string>
+						</object>
+						<object class="NSTextField" id="538635083">
+							<reference key="NSNextResponder" ref="248881203"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{17, 290}, {82, 17}}</string>
+							<reference key="NSSuperview" ref="248881203"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="945329815"/>
+							<int key="NSViewLayerContentsRedrawPolicy">2</int>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="929072009">
+								<int key="NSCellFlags">68288064</int>
+								<int key="NSCellFlags2">71304192</int>
+								<string key="NSContents">Insert Only</string>
+								<reference key="NSSupport" ref="752916645"/>
+								<reference key="NSControlView" ref="538635083"/>
+								<reference key="NSBackgroundColor" ref="641415861"/>
+								<reference key="NSTextColor" ref="556299165"/>
+							</object>
+						</object>
+						<object class="NSTextField" id="264776498">
+							<reference key="NSNextResponder" ref="248881203"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{303, 348}, {68, 17}}</string>
+							<reference key="NSSuperview" ref="248881203"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="521699642"/>
+							<string key="NSReuseIdentifierKey">_NS:3944</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="920355113">
+								<int key="NSCellFlags">68288064</int>
+								<int key="NSCellFlags2">138413056</int>
+								<string key="NSContents">Shortcut</string>
+								<reference key="NSSupport" ref="752916645"/>
+								<string key="NSCellIdentifier">_NS:3944</string>
+								<reference key="NSControlView" ref="264776498"/>
+								<reference key="NSBackgroundColor" ref="641415861"/>
+								<reference key="NSTextColor" ref="556299165"/>
+							</object>
+						</object>
 					</object>
-					<string key="NSFrameSize">{435, 331}</string>
+					<string key="NSFrameSize">{435, 385}</string>
 					<reference key="NSSuperview"/>
 					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="264776498"/>
 					<int key="NSViewLayerContentsRedrawPolicy">2</int>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1920, 1178}}</string>
+				<string key="NSScreenRect">{{0, 0}, {1680, 1050}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<string key="NSFrameAutosaveName">QuickCursorPreferences</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
@@ -779,14 +872,6 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBActionConnection" key="connection">
-						<string key="label">editInPopUpButtonClicked:</string>
-						<reference key="source" ref="976324537"/>
-						<reference key="destination" ref="1039590887"/>
-					</object>
-					<int key="connectionID">551</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
 						<string key="label">showPreferences:</string>
 						<reference key="source" ref="976324537"/>
 						<reference key="destination" ref="836189708"/>
@@ -803,11 +888,43 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
-						<string key="label">shortcutRecorder</string>
+						<string key="label">insertInPopUpButton</string>
+						<reference key="source" ref="976324537"/>
+						<reference key="destination" ref="945329815"/>
+					</object>
+					<int key="connectionID">900</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">insertShortcutRecorder</string>
+						<reference key="source" ref="976324537"/>
+						<reference key="destination" ref="155242521"/>
+					</object>
+					<int key="connectionID">901</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">editShortcutRecorder</string>
 						<reference key="source" ref="976324537"/>
 						<reference key="destination" ref="868578286"/>
 					</object>
-					<int key="connectionID">887</int>
+					<int key="connectionID">902</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">popUpButtonClicked:</string>
+						<reference key="source" ref="976324537"/>
+						<reference key="destination" ref="945329815"/>
+					</object>
+					<int key="connectionID">904</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">popUpButtonClicked:</string>
+						<reference key="source" ref="976324537"/>
+						<reference key="destination" ref="1039590887"/>
+					</object>
+					<int key="connectionID">905</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
@@ -902,6 +1019,14 @@
 					</object>
 					<int key="connectionID">886</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">delegate</string>
+						<reference key="source" ref="155242521"/>
+						<reference key="destination" ref="1021"/>
+					</object>
+					<int key="connectionID">893</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -958,12 +1083,16 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<reference ref="1039590887"/>
 							<reference ref="521699642"/>
+							<reference ref="868578286"/>
+							<reference ref="945329815"/>
+							<reference ref="155242521"/>
+							<reference ref="538635083"/>
+							<reference ref="264776498"/>
 							<reference ref="278119067"/>
 							<reference ref="942101536"/>
 							<reference ref="138723173"/>
 							<reference ref="7174257"/>
 							<reference ref="659126509"/>
-							<reference ref="868578286"/>
 						</object>
 						<reference key="parent" ref="448742277"/>
 					</object>
@@ -1303,6 +1432,62 @@
 						<reference key="object" ref="868578286"/>
 						<reference key="parent" ref="248881203"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">888</int>
+						<reference key="object" ref="945329815"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="664626514"/>
+						</object>
+						<reference key="parent" ref="248881203"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">889</int>
+						<reference key="object" ref="664626514"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="769083916"/>
+						</object>
+						<reference key="parent" ref="945329815"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">890</int>
+						<reference key="object" ref="769083916"/>
+						<reference key="parent" ref="664626514"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">892</int>
+						<reference key="object" ref="155242521"/>
+						<reference key="parent" ref="248881203"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">894</int>
+						<reference key="object" ref="538635083"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="929072009"/>
+						</object>
+						<reference key="parent" ref="248881203"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">895</int>
+						<reference key="object" ref="929072009"/>
+						<reference key="parent" ref="538635083"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">898</int>
+						<reference key="object" ref="264776498"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="920355113"/>
+						</object>
+						<reference key="parent" ref="248881203"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">899</int>
+						<reference key="object" ref="920355113"/>
+						<reference key="parent" ref="264776498"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -1319,6 +1504,7 @@
 					<string>533.NSWindowTemplate.visibleAtLaunch</string>
 					<string>534.IBPluginDependency</string>
 					<string>540.IBPluginDependency</string>
+					<string>540.userInterfaceItemIdentifier</string>
 					<string>541.IBPluginDependency</string>
 					<string>542.IBPluginDependency</string>
 					<string>547.IBPluginDependency</string>
@@ -1369,6 +1555,15 @@
 					<string>871.IBPluginDependency</string>
 					<string>872.IBPluginDependency</string>
 					<string>885.IBPluginDependency</string>
+					<string>888.IBPluginDependency</string>
+					<string>888.userInterfaceItemIdentifier</string>
+					<string>889.IBPluginDependency</string>
+					<string>890.IBPluginDependency</string>
+					<string>892.IBPluginDependency</string>
+					<string>894.IBPluginDependency</string>
+					<string>895.IBPluginDependency</string>
+					<string>898.IBPluginDependency</string>
+					<string>899.IBPluginDependency</string>
 				</object>
 				<object class="NSMutableArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
@@ -1382,6 +1577,7 @@
 					<boolean value="NO"/>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>edit</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1432,6 +1628,15 @@
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>insert</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="unlocalizedProperties">
@@ -1446,7 +1651,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">887</int>
+			<int key="maxID">905</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -1458,8 +1663,8 @@
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>beginQuickCursorEdit:</string>
-							<string>editInPopUpButtonClicked:</string>
+							<string>beginQuickCursorAction:</string>
+							<string>popUpButtonClicked:</string>
 							<string>showAbout:</string>
 							<string>showHelp:</string>
 							<string>showPreferences:</string>
@@ -1477,8 +1682,8 @@
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>beginQuickCursorEdit:</string>
-							<string>editInPopUpButtonClicked:</string>
+							<string>beginQuickCursorAction:</string>
+							<string>popUpButtonClicked:</string>
 							<string>showAbout:</string>
 							<string>showHelp:</string>
 							<string>showPreferences:</string>
@@ -1486,11 +1691,11 @@
 						<object class="NSMutableArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<object class="IBActionInfo">
-								<string key="name">beginQuickCursorEdit:</string>
+								<string key="name">beginQuickCursorAction:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
-								<string key="name">editInPopUpButtonClicked:</string>
+								<string key="name">popUpButtonClicked:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
@@ -1512,16 +1717,20 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>editInPopUpButton</string>
+							<string>editShortcutRecorder</string>
+							<string>insertInPopUpButton</string>
+							<string>insertShortcutRecorder</string>
 							<string>openAtLogin</string>
 							<string>preferencesWindow</string>
-							<string>shortcutRecorder</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>NSPopUpButton</string>
+							<string>SRRecorderControl</string>
+							<string>NSPopUpButton</string>
+							<string>SRRecorderControl</string>
 							<string>NSButton</string>
 							<string>NSWindow</string>
-							<string>SRRecorderControl</string>
 						</object>
 					</object>
 					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
@@ -1529,9 +1738,11 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>editInPopUpButton</string>
+							<string>editShortcutRecorder</string>
+							<string>insertInPopUpButton</string>
+							<string>insertShortcutRecorder</string>
 							<string>openAtLogin</string>
 							<string>preferencesWindow</string>
-							<string>shortcutRecorder</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
@@ -1540,16 +1751,24 @@
 								<string key="candidateClassName">NSPopUpButton</string>
 							</object>
 							<object class="IBToOneOutletInfo">
+								<string key="name">editShortcutRecorder</string>
+								<string key="candidateClassName">SRRecorderControl</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">insertInPopUpButton</string>
+								<string key="candidateClassName">NSPopUpButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">insertShortcutRecorder</string>
+								<string key="candidateClassName">SRRecorderControl</string>
+							</object>
+							<object class="IBToOneOutletInfo">
 								<string key="name">openAtLogin</string>
 								<string key="candidateClassName">NSButton</string>
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">preferencesWindow</string>
 								<string key="candidateClassName">NSWindow</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">shortcutRecorder</string>
-								<string key="candidateClassName">SRRecorderControl</string>
 							</object>
 						</object>
 					</object>

--- a/QCAppDelegate.h
+++ b/QCAppDelegate.h
@@ -8,22 +8,36 @@
 
 #import <Cocoa/Cocoa.h>
 #import <ShortcutRecorder/ShortcutRecorder.h>
-
+#import "QCSRDelegate.h"
+#import "PTKeyCombo.h"
 
 @class PTHotKey;
+@class QCSRDelegate;
+
+extern NSString * const TYPE_EDIT;
+extern NSString * const TYPE_INSERT;
 
 @interface QCAppDelegate : NSObject {
 	IBOutlet NSWindow *preferencesWindow;
-	IBOutlet NSPopUpButton *editInPopUpButton;
-	IBOutlet SRRecorderControl *shortcutRecorder;
 	IBOutlet NSButton *openAtLogin;
-	
+
+    /* Keyboard shortcut popups and controls */
+    IBOutlet NSPopUpButton *editInPopUpButton;
+    IBOutlet NSPopUpButton *insertInPopUpButton;
+	IBOutlet SRRecorderControl *editShortcutRecorder;
+    IBOutlet SRRecorderControl *insertShortcutRecorder;
+    
 	NSStatusItem *quickCursorStatusItem;
 	NSMutableSet *quickCursorSessionQCUIElements;
 	NSMutableArray *registeredHotKeys;
+    
+    QCSRDelegate *editSRDelegate;
+    QCSRDelegate *insertSRDelegate;
 }
 
 + (BOOL)universalAccessNeedsToBeTurnedOn;
++ (NSString *)makeUserDefaultString:(NSDictionary *)representedObject;
+- (void)updateHotKeys:(NSString *)userDefaultString addingKeyCombo:(PTKeyCombo *)newKeyCombo usingRecorder:(SRRecorderControl *)addingWithRecorder;
 
 //@property(assign) BOOL enableLoginItem;
 
@@ -32,7 +46,9 @@
 - (IBAction)showHelp:(id)sender;	
 - (IBAction)showAbout:(id)sender;	
 - (IBAction)showPreferences:(id)sender;
-- (IBAction)editInPopUpButtonClicked:(id)sender;
-- (IBAction)beginQuickCursorEdit:(id)sender;	
+- (IBAction)beginQuickCursorAction:(id)sender;	
+
+/* Generic function for any shortcut popup button */
+- (IBAction)popUpButtonClicked:(id)sender;
 
 @end

--- a/QCSRDelegate.h
+++ b/QCSRDelegate.h
@@ -1,0 +1,25 @@
+//
+//  QCSRDelegate.h
+//  QuickCursor
+//
+//  Created by Ryan Graciano on 12/8/11.
+//  Copyright (c) 2011. All rights reserved.
+//
+//  One shortcut recorder control is used by each Edit and Insert.
+//  This class serves as a delegate for the SRRecorderControl
+//  and remembers which type of action (edit/ins) it's delegating.
+
+#import <Cocoa/Cocoa.h>
+#import <ShortcutRecorder/ShortcutRecorder.h>
+#import "QCAppDelegate.h"
+
+@class QCAppDelegate;
+
+@interface QCSRDelegate : NSObject {
+    NSPopUpButton *targetBtn;
+    QCAppDelegate *owner;
+}
+
+- (id)initWithOwnerAndBtn:(id)newOwner popUpButton:(NSPopUpButton *)popUpButton;
+
+@end

--- a/QCSRDelegate.m
+++ b/QCSRDelegate.m
@@ -1,0 +1,47 @@
+//
+//  QCSRDelegate.m
+//  QuickCursor
+//
+//  Created by Ryan Graciano on 12/8/11.
+//  Copyright (c) 2011. All rights reserved.
+//
+
+#import "QCSRDelegate.h"
+#import "PTHotKey.h"
+#import "QCAppDelegate.h"
+
+@implementation QCSRDelegate
+
+- (void)shortcutRecorder:(SRRecorderControl *)aRecorder keyComboDidChange:(KeyCombo)newKeyCombo {
+    signed short code = newKeyCombo.code;
+	unsigned int flags = [aRecorder cocoaToCarbonFlags:newKeyCombo.flags];
+	PTKeyCombo *keyCombo = [[[PTKeyCombo alloc] initWithKeyCode:code modifiers:flags] autorelease];
+
+	NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *userDefaultString = [QCAppDelegate makeUserDefaultString:[[targetBtn selectedItem] representedObject]];
+	[userDefaults setObject:[keyCombo plistRepresentation] forKey:userDefaultString];
+    
+	[owner updateHotKeys:userDefaultString addingKeyCombo:keyCombo usingRecorder:aRecorder];
+	[userDefaults synchronize];
+}
+
+- (id)initWithOwnerAndBtn:(id)newOwner popUpButton:(NSPopUpButton *)popUpButton {
+    self = [super init];
+    
+    if (self) {
+        owner = newOwner;
+        [owner retain];
+        
+        targetBtn = popUpButton;
+        [targetBtn retain];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [owner release];
+    [targetBtn release];
+    [super dealloc];
+}
+
+@end

--- a/QuickCursor.xcodeproj/project.pbxproj
+++ b/QuickCursor.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		9496F7961490A85500D429FB /* QCSRDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9496F7951490A85500D429FB /* QCSRDelegate.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -100,6 +101,8 @@
 		88D3FC46133D0F8B00C2E651 /* ReceiptVerification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReceiptVerification.h; sourceTree = "<group>"; };
 		88D3FC47133D0F8B00C2E651 /* ReceiptVerification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReceiptVerification.m; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* QuickCursor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuickCursor.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9496F7941490A85500D429FB /* QCSRDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QCSRDelegate.h; sourceTree = "<group>"; };
+		9496F7951490A85500D429FB /* QCSRDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QCSRDelegate.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +135,8 @@
 				88C3174C1469D7E0003E71E0 /* NSPasteboard_Extensions.m */,
 				882A8C26128C368400D05C94 /* ODB Editor */,
 				882A8C27128C369100D05C94 /* Hot Key */,
+				9496F7941490A85500D429FB /* QCSRDelegate.h */,
+				9496F7951490A85500D429FB /* QCSRDelegate.m */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -331,6 +336,7 @@
 				882A8BDD128C349F00D05C94 /* NSAppleEventDescriptor-Extensions.m in Sources */,
 				88D3FC48133D0F8B00C2E651 /* ReceiptVerification.m in Sources */,
 				88C3174D1469D7E0003E71E0 /* NSPasteboard_Extensions.m in Sources */,
+				9496F7961490A85500D429FB /* QCSRDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
My last commit message sums up this change pretty well.  This is a substantial upgrade, in that it enables an additional workflow (one I use frequently - email).  Hope you find it useful!  Let me know if you have any questions.  Also if you do make use of this, I'd appreciate a footnote someplace mentioning my name as a contributor.

Best,
-Ryan

Commit message:

```
Currently, QuickCursor always copies all text from the target window
before opening the external editor.  After the editor is opened and
the text is edited, QuickCursor eliminates everything from the original
buffer in the paste.

This is not so great if you are, say, replying to an email and only want
to edit your response in the external editor without destroying the rest
of the email chain.  Hence, "insert" - "insert" will NOT copy or select
the buffer before opening the external editor.  It'll just open up the
editor, and upon save/quit, it'll paste the text back in at the cursor.

While I was in there, I also made one or two minor enhancements.
Now, if you pick a shortcut that is already in use, the app will
look through the existing shortcuts and remove dupes. This also
works with the Edit/Insert feature; the app will actually pull the
dupe shortcut out of the other control if it's currently displaying.

This is the first thing I have ever done in Objective-C, so
apologies if I'm slightly off on common idioms and that sort of
thing.
```
