### PR TITLE
Added support for Mou app natively

### DIFF
--- a/QuickCursor-Info.plist
+++ b/QuickCursor-Info.plist
@@ -53,6 +53,7 @@
 		<string>jp.informationarchitects.WriterForMacOSX</string>
 		<string>com.hogbaysoftware.WriteRoom</string>
 		<string>com.hogbaysoftware.WriteRoom.mac</string>
+		<string>com.mouapp.mou</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
You already can add ODB apps in Preferences, but I've made it available by default since Mou app is really great to work with Markdown files.
