### PR TITLE
add Emacs

### DIFF
--- a/QuickCursor-Info.plist
+++ b/QuickCursor-Info.plist
@@ -55,6 +55,7 @@
 		<string>com.hogbaysoftware.WriteRoom</string>
 		<string>com.hogbaysoftware.WriteRoom.mac</string>
 		<string>com.mouapp.mou</string>
+		<string>org.gnu.Emacs</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The mac port of Emacs supports ODB out of the box, and is specifically tested with quickcursor.

see https://github.com/railwaycat/emacs-mac-port
